### PR TITLE
Fix wifi_name retrieval

### DIFF
--- a/wifi-loc-control.sh
+++ b/wifi-loc-control.sh
@@ -19,7 +19,7 @@ log() {
 }
 
 # Get the Wi-Fi network name (SSID)
-wifi_name="$(networksetup -getairportnetwork en0 | awk -F ': ' '{print $2}')"
+wifi_name="$(ipconfig getsummary en0 | awk -F ' SSID : '  '/ SSID : / {print $2}')"
 log "current wifi_name '$wifi_name'"
 
 if [ "$wifi_name" == "" ]; then


### PR DESCRIPTION
In Sequoia, running `networksetup -getairportnetwork en0` returns `You are not associated with an AirPort network.`
Therefore the script wifi-loc-control.sh only returns: 
You are not associated with an AirPort network.

The change in this PR uses ipconfig to retrieve the SSID.

Fixes #5 