### PR TITLE
fix(bootstrap): add sudo to install commands for system directories

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -12,10 +12,10 @@ CONFIG_DIR=$HOME/.wifi-loc-control
 sudo -v
 
 mkdir -p $INSTALL_DIR
-cp -f $SCRIPT_NAME $INSTALL_DIR
+sudo cp -f $SCRIPT_NAME $INSTALL_DIR
 
 # Set exec permissions for script
-chmod +x $INSTALL_DIR$SCRIPT_NAME
+sudo chmod +x $INSTALL_DIR$SCRIPT_NAME
 
 mkdir -p $CONFIG_DIR
 


### PR DESCRIPTION
**What this does:**
Adds sudo to the cp and chmod commands in bootstrap.sh to ensure proper permissions when copying the `wifi-loc-control.sh` script to `/usr/local/bin/`.

**Why this is needed:**
Without sudo, users may encounter Permission denied errors when running the bootstrap script on systems where `/usr/local/bin/` is not writable by default (common on recent macOS versions).

**Changes made:**
- Added sudo to the cp and chmod lines in bootstrap.sh.