### PR TITLE
Fix wifi name retrieval for MacOS Tahoe 26.0

### DIFF
--- a/wifi-loc-control.sh
+++ b/wifi-loc-control.sh
@@ -19,7 +19,7 @@ log() {
 }
 
 # Get the Wi-Fi network name (SSID)
-wifi_name="$(/usr/libexec/PlistBuddy -c 'Print :0:_items:0:spairport_airport_interfaces:0:spairport_current_network_information:_name' /dev/stdin <<< "$(system_profiler SPAirPortDataType -xml)" 2> /dev/null)"
+wifi_name="$(networksetup -listpreferredwirelessnetworks en0 | sed -n '2 p' | tr -d '\t')"
 log "current wifi_name '$wifi_name'"
 
 if [ "$wifi_name" == "" ]; then


### PR DESCRIPTION
The fixed used for Sequoia in this [PR](https://github.com/vborodulin/wifi-loc-control/pull/11) unfortunately doesn't work for Tahoe 26.0. Logs show the wifi network as `<redacted>`

Based on my research and testing `networksetup -listpreferredwirelessnetworks en0` always lists the currently connected network first in the list. Open to suggestions if others have a better solution.