### PR TITLE
Allow to use the Wi-Fi mac address to find network location aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,16 @@ My_Home_Wi-Fi_2.4GHz=Work
 
 Where the keys are the wireless network names and the values are the desired location names.
 
+You can also use the private and fixed Wi-Fi address that macOS can generate for each Wi-Fi network:
+
+```
+# My_Home_Wi-Fi_5GHz
+d2:1a:f8:5d:bb:ac=Home
+
+# My_Home_Wi-Fi_2.4GHz
+cf:0a:4e:8a:4b:fe=Home
+```
+
 ### Run Scripts on Wi-Fi Network Connection
 
 Sometimes you want to execute a script every time you connect to a specific Wi-Fi network. For

--- a/wifi-loc-control.sh
+++ b/wifi-loc-control.sh
@@ -19,13 +19,20 @@ log() {
 }
 
 
+# Get the Wi-Fi interface name
+get_wifi_interface() {
+  networksetup -listallhardwareports | grep -A1 'Hardware Port: Wi-Fi' | tail -1 | awk '{print $2}'
+}
+
 # Get the Wi-Fi network name (SSID)
 # Try multiple methods for compatibility with different macOS versions
 get_wifi_name() {
+  wifi_interface="$(get_wifi_interface)"
+
   # Method 1: Try the new approach for macOS 26+ (Sequoia 15.6+)
   if command -v ipconfig >/dev/null 2>&1; then
     # First try without sudo (might work in some cases)
-    wifi_name_new=$(ipconfig getsummary en0 2>/dev/null | awk -F ' SSID : ' '/ SSID : / {print $2}' | tr -d '\n')
+    wifi_name_new=$(ipconfig getsummary "$wifi_interface" 2>/dev/null | awk -F ' SSID : ' '/ SSID : / {print $2}' | tr -d '\n')
     
     if [[ -n "$wifi_name_new" && "$wifi_name_new" != "<redacted>" && "$wifi_name_new" != "< redacted >" ]]; then
       echo "$wifi_name_new"
@@ -35,7 +42,7 @@ get_wifi_name() {
     # Try with sudo verbose mode for macOS 26+
     if sudo -n ipconfig setverbose 1 >/dev/null 2>&1; then
       sudo ipconfig setverbose 1 >/dev/null 2>&1
-      wifi_name_verbose=$(ipconfig getsummary en0 2>/dev/null | awk -F ' SSID : ' '/ SSID : / {print $2}' | tr -d '\n')
+      wifi_name_verbose=$(ipconfig getsummary "$wifi_interface" 2>/dev/null | awk -F ' SSID : ' '/ SSID : / {print $2}' | tr -d '\n')
       sudo ipconfig setverbose 0 >/dev/null 2>&1
       
       if [[ -n "$wifi_name_verbose" && "$wifi_name_verbose" != "<redacted>" && "$wifi_name_verbose" != "< redacted >" ]]; then
@@ -54,7 +61,7 @@ get_wifi_name() {
   fi
   
   # Method 3: Fallback to original method (for older macOS)
-  wifi_name_fallback=$(networksetup -listpreferredwirelessnetworks en0 | sed -n '2 p' | tr -d '\t')
+  wifi_name_fallback=$(networksetup -listpreferredwirelessnetworks "$wifi_interface" | sed -n '2 p' | tr -d '\t')
   
   if [[ -n "$wifi_name_fallback" && "$wifi_name_fallback" != "<redacted>" && "$wifi_name_fallback" != "< redacted >" ]]; then
     echo "$wifi_name_fallback"
@@ -65,12 +72,19 @@ get_wifi_name() {
   echo ""
 }
 
-wifi_name="$(get_wifi_name)"
-log "current wifi_name '$wifi_name'"
+# Get the Wi-Fi MAC address used for the current network.
+# By default, macOS assigns a unique and random MAC address to each SSID, allowing to map networks to locations.
+get_wifi_mac_address() {
+  wifi_interface="$(get_wifi_interface)"
+  ifconfig "$wifi_interface" | awk '/ether/{print $2}'
+}
 
-if [ "$wifi_name" == "" ] || [ "$wifi_name" == "<redacted>" ] || [ "$wifi_name" == "< redacted >" ]; then
-  log "wifi_name is empty or redacted - this may be due to macOS 26+ privacy restrictions"
-  log "If you're on macOS 26+, ensure the bootstrap script was run to set up sudo permissions"
+wifi_name="$(get_wifi_name)"
+wifi_mac_address="$(get_wifi_mac_address)"
+log "current wifi_name '$wifi_name' and wifi_mac_address '$wifi_mac_address'"
+
+if [[ ( "$wifi_name" == "" || "$wifi_name" == "<redacted>" || "$wifi_name" == "< redacted >" ) && "$wifi_mac_address" == "" ]]; then
+  log "wifi_name is empty or redacted, and wifi_mac_address is empty"
   exit 0
 fi
 
@@ -86,13 +100,17 @@ log "current network location '$current_network_location'"
 alias_location=$wifi_name
 if [ -f "$ALIAS_CONFIG_PATH" ]; then
   log "reading alias config '$ALIAS_CONFIG_PATH'"
-  alias=$(grep "$wifi_name=" "$ALIAS_CONFIG_PATH" | sed -nE 's/.*=(.*)/\1/p')
+  wifi_alias=$(awk -v key="$wifi_name" -F'=' '$1 == key { print $2 }' "$ALIAS_CONFIG_PATH")
+  mac_alias=$(awk -v key="$wifi_mac_address" -F'=' 'tolower($1) == tolower(key) { print $2 }' "$ALIAS_CONFIG_PATH")
 
-  if [ "$alias" != "" ]; then
-    alias_location=$alias
-    log "for wifi name '$wifi_name' found alias '$alias_location'"
+  if [ "$wifi_alias" != "" ]; then
+    alias_location=$wifi_alias
+    log "for wifi_name '$wifi_name' found alias '$alias_location'"
+  elif [ "$mac_alias" != "" ]; then
+    alias_location=$mac_alias
+    log "for wifi_mac_address '$wifi_mac_address' found alias '$alias_location'"
   else
-    log "for wifi name '$wifi_name' alias not found"
+    log "for wifi_name '$wifi_name' and wifi_mac_address '$wifi_mac_address' alias not found"
   fi
 fi
 


### PR DESCRIPTION
Due to privacy reasons macOS hides the SSID of the current network. root can still see the network, while regular users can only guess it using workarounds such as looking at the order of the preferred network list, which is not reliable and might not work in future.

A more reliable way to detect the current network is that of reading the MAC address used to connect to some Wi-Fi network. Each saved network gets by default a unique, random and fixed MAC address. This allows to map Wi-Fi networks to network locations.

Given that naming network locations using a MAC address looks awkward, the mapping with the MAC address can only be done via alias.conf. SSID aliases take precedence.

Note: the alias parser now discards all the lines not starting with a SSID followed immediately by `=`. This allows to write comments in the file, useful when writing aliases for MAC addresses.